### PR TITLE
Minimal fixes

### DIFF
--- a/main.py
+++ b/main.py
@@ -543,7 +543,7 @@ def extract_anime_title_for_guessit(episode_filepath):
     This allows guessit to return "Shingeki No Kyojin" as the anime title, instead of returning the episode title
     """
     return re.sub(
-        "[.*?]|1080p|720p|BDRip|Dual\s?Audio|x?26[4|5]-?|HEVC|10\sbits|EMBER",
+        "\[.*?]|1080p|720p|BDRip|Dual\s?Audio|x?26[4|5]-?|HEVC|10\sbits|EMBER",
         "",
         " ".join(episode_filepath.split("/")[-2:]),
     )

--- a/main.py
+++ b/main.py
@@ -240,8 +240,19 @@ def main():
             for subtitle_stream in subtitle_streams:
                 index = subtitle_stream["index"]
                 codec = subtitle_stream["codec_name"]
+                tag_language = subtitle_stream["tags"]["language"]
+
+                # Support for non-ISO 639-3 language tags
+                tag_language_normalizer = {
+                    "fre": "fra",
+                    "ger": "deu"
+                }
+
+                if(tag_language_normalizer.get(tag_language)):
+                    tag_language = tag_language_normalizer.get(tag_language)
+
                 subtitle_language = babelfish.Language(
-                    subtitle_stream["tags"]["language"]
+                    tag_language
                 ).alpha2
                 logging.info(
                     f"Found internal subtitle stream. Index: {index}. Codec: {codec}. Language: {subtitle_language}"

--- a/main.py
+++ b/main.py
@@ -512,7 +512,7 @@ def process_subtitle_line(line):
         return ""
 
     # Normaliza half-width (Hankaku) a full-width (Zenkaku) caracteres
-    processed_sentence = jaconvV2.normalize(line.plaintext, "NFKC")
+    processed_sentence = jaconvV2.normalize(line.plaintext, "NFKC").replace('\n', ' ').replace('\r', '')
     special_chars = [
         "\(\(.*?\)\)",
         "\（.*?\）",


### PR DESCRIPTION
- The Regex pattern that cleans the title has been fixed to work on Windows/Linux by adding "\" at the beginning of the statement. https://github.com/BrigadaSOS/media-sub-splitter/commit/a28335c743b6a36644052cbe2f82c5dfb7f1602d

- When processing a file with multiple languages, some language tags did not match the ISO 639-3 format, resulting in an error in the `Babelfish` library. https://github.com/BrigadaSOS/media-sub-splitter/commit/7b156ea065dbd8a09108bae62eb84cd2ac80b446

- Line breaks removed from preprocessed sentences. Otherwise, the CSV file would be improperly formatted. https://github.com/BrigadaSOS/media-sub-splitter/commit/a0d1c834da3e0606c315e3c5834e6c19c03a94e1


